### PR TITLE
Fix example with promised way

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ var options = {
 
 var css = fs.readFileSync('input.css', 'utf8');
 
-var output = postcss()
+postcss()
   .use(functions(options))
   .process(css)
-  .css;
+  .then(function (result) {
+    var output = result.css;
+  });
 ```
 
 **Example** of a function call:


### PR DESCRIPTION
`process().css` is just for debug and it shouldn't be used in production code. Also it shouldn't be an example of usage caz it can confuse users.
