### PR TITLE
Added a `walk` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,19 @@ require('postcss-functions')({
 	glob: path.join(__dirname, 'functions', '*.js')
 });
 ```
+### `walk`
+
+Type: `function`
+
+By default, the plugin walks all the nodes of the AST. You can use the `walk` option to provide your own walking function.
+
+**Example:**
+
+```js
+require('postcss-functions')({
+  // Only walk declarations of matching /background/
+  walk: function (css, cb) {
+    css.walkDecls(/background/,cb);
+  }
+});
+```

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -149,6 +149,21 @@ test(
 );
 
 test(
+    'should use custom walk function',
+    testFixture,
+    'a{background:foo(); border: foo();} .foo(){}',
+    'a{background:bar; border: foo();} .foo(){}',
+    {
+        functions: {
+            foo: () => 'bar'
+        },
+        walk: function (css, cb) {
+            css.walkDecls(/background/,cb);
+        }
+    }
+);
+
+test(
     'should not pass empty arguments', 
     t => {
 		return postcss(functions({

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {hasPromises} from './lib/helpers'
 
 export default plugin('postcss-functions', (opts = {}) => {
 	const functions = opts.functions || {};
+	const walk = opts.walk || ((css,cb) => css.walk(cb));
 	let globs = opts.glob || [];
 
 	if (!Array.isArray(globs))
@@ -24,7 +25,7 @@ export default plugin('postcss-functions', (opts = {}) => {
 
 	return css => {
 		const promises = [];
-		css.walk(node => {
+		walk(css, node => {
 			promises.push(transform(node));
 		});
 		


### PR DESCRIPTION
I needed a way to customize which nodes were walked through so I added a `walk` option allowing users to customise the walking (eg. use `walkDecls` instead of just `walk`).