### PR TITLE
Add options to ignore specific at-rules and properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.0 - 2024-10-04
+* Add `ignoredAtRules` option.
+* Add `ignoredProps` option.
+
 # 4.0.2 - 2020-11-08
 * Update to PostCSS 8.
 * Remove `glob` option. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-functions",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "PostCSS plugin for exposing JavaScript functions",
   "main": "dest/index.js",
   "scripts": {

--- a/src/__tests__/index.mjs
+++ b/src/__tests__/index.mjs
@@ -26,6 +26,21 @@ test(
 );
 
 test(
+    'should skip ignored props',
+    testFixture,
+    'a{foo:bar()}',
+    null,
+    {
+        functions: {
+            'bar': function () {
+                return 'baz';
+            }
+        },
+        ignoredProps: ['foo']
+    }
+);
+
+test(
     'should accept deferred functions',
     testFixture,
     'a{foo:bar()}',
@@ -101,6 +116,21 @@ test(
                 return 'baz';
             }
         }
+    }
+);
+
+test(
+    'should skip ignored at-rules',
+    testFixture,
+    '@foo bar(){bat:qux}',
+    null,
+    {
+        functions: {
+            'bar': function () {
+                return 'baz';
+            }
+        },
+        ignoredAtRules: ['foo']
     }
 );
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,18 +1,20 @@
 import { transformAtRule, transformDecl, transformRule } from './lib/transformer.mjs';
 
 function plugin(opts = {}) {
-	const functions = opts.functions || {};
+	opts.functions = opts.functions || {}
+	opts.ignoredAtRules = opts.ignoredAtRules || []
+	opts.ignoredProps = opts.ignoredProps || []
 
 	return {
 		postcssPlugin: 'postcss-functions',
 		AtRule(node) {
-			return transformAtRule(node, functions);
+			return transformAtRule(node, opts);
 		},
 		Declaration(node) {
-			return transformDecl(node, functions);
+			return transformDecl(node, opts);
 		},
 		Rule(node) {
-			return transformRule(node, functions);
+			return transformRule(node, opts);
 		}
 	}
 }

--- a/src/lib/transformer.mjs
+++ b/src/lib/transformer.mjs
@@ -56,19 +56,23 @@ function extractArgs(nodes, functions) {
     });
 }
 
-export function transformDecl(node, functions) {
+export function transformDecl(node, { functions, ignoredProps }) {
+    if (ignoredProps.includes(node.prop)) return node;
+
     return then(transformString(node.value, functions), value => {
         node.value = value;
     });
 }
 
-export function transformAtRule(node, functions) {
+export function transformAtRule(node, { functions, ignoredAtRules }) {
+    if (ignoredAtRules.includes(node.name)) return node
+
     return then(transformString(node.params, functions), value => {
         node.params = value;
     });
 }
 
-export function transformRule(node, functions) {
+export function transformRule(node, { functions }) {
     return then(transformString(node.selector, functions), value => {
         node.selector = value;
     });


### PR DESCRIPTION
I ran into an issue with a project that had a mixin and a function that shared the same name. This change should resolve that issue, allowing users to specify at-rules that should be skipped when transforming functions.

I included an option for ignoring specific props as well, as I figured it could be useful in some circumstances.